### PR TITLE
Search for scripts in `.skyr`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Skyr / Change Log
 
+## Unreleased
+
+### Added
+
+* [#9](https://github.com/kytta/skyr/issues/9):
+  Allow execution of scripts from `./.skyr/`.
+
+### Changed
+
+* due to [#9](https://github.com/kytta/skyr/issues/9):
+  script directory resolution logic was changed: if provided script dir doesn't
+  exist, Skyr will fall back to `./.skyr/`, then `./script/`
+
 ## 0.1.1 - 2023-03-29
 
 ## Fixed
@@ -11,7 +24,7 @@
 
 * [#7](https://github.com/kytta/skyr/pull/7):
   Eat our own dog food
-  * this means, Skyr uses Skyr scripts ✨ 
+  * this means, Skyr uses Skyr scripts ✨
 * [#12](https://github.com/kytta/skyr/pull/12):
   Add GitHub Pages site
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ If you don't provide the script name, it will default to `build`:
 skyr  # same as 'skyr build'
 ```
 
-By default, Skyr searches for your scripts inside `./script`. To change that,
-use `--script-dir`:
+By default, Skyr searches for your scripts inside `./.skyr/` and `./script`. To
+change that, use `--script-dir`:
 
 ```sh
 skyr --script-dir ./dev/ test

--- a/skyr.py
+++ b/skyr.py
@@ -41,19 +41,13 @@ def find_dir(
     return None
 
 
-def find_script(name: str, script_dir: Path = DEFAULT_DIR) -> Optional[Path]:
-    """Tries to find a script to run."""
-    resolved_script_dir = script_dir.resolve()
+def find_script(name: str, script_dir: Path) -> Optional[Path]:
+    """Tries to find a script to run.
 
-    if not resolved_script_dir.exists():
-        _err(f"Script directory doesn't exist: {str(resolved_script_dir)}")
-        return None
-
-    if not resolved_script_dir.is_dir():
-        _err(f"Script directory is not a directory: {str(script_dir)}")
-        return None
-
-    script_file = resolved_script_dir / name
+    :param name: Name of the script
+    :param script_dir: Directory to search for the scripts
+    """
+    script_file = (script_dir / name).resolve()
 
     if not script_file.exists():
         _err(f"Script doesn't exist: {str(script_file)}")

--- a/skyr.py
+++ b/skyr.py
@@ -126,13 +126,21 @@ def _get_parser() -> argparse.ArgumentParser:
 def main(argv: Optional[Sequence[str]] = None) -> NoReturn:
     args, rest = _get_parser().parse_known_args(argv)
 
-    script_file = find_script(args.script, script_dir=args.script_dir)
+    candidates = [args.script_dir, Path(".skyr"), Path("script")]
+    script_dir = find_dir(candidates)
+    if script_dir is None:
+        _err(
+            f"No script directory found. "
+            f"Searched in: {', '.join([str(c) for c in candidates if c])}",
+        )
+        raise SystemExit(1)
 
+    script_file = find_script(args.script, script_dir=script_dir)
     if script_file is None:
         _err(f"Couldn't find script {args.script!r}")
         raise SystemExit(1)
 
-    try_execute(f"{args.script_dir / args.script}", script_file, rest)
+    try_execute(f"{script_dir / args.script}", script_file, rest)
 
 
 if __name__ == "__main__":

--- a/skyr.py
+++ b/skyr.py
@@ -25,9 +25,7 @@ def _err(msg: str) -> None:
     sys.stderr.flush()
 
 
-def find_dir(
-    candidates: Iterable[Union[str, os.PathLike[str], Path]],
-) -> Optional[Path]:
+def find_dir(candidates: Iterable[Union[str, Path]]) -> Optional[Path]:
     """Searches an array for an existent directory.
 
     :param candidates: Directories or names that will be searched

--- a/skyr.py
+++ b/skyr.py
@@ -5,10 +5,12 @@ import os
 import sys
 from importlib import metadata
 from pathlib import Path
+from typing import Iterable
 from typing import List
 from typing import NoReturn
 from typing import Optional
 from typing import Sequence
+from typing import Union
 
 __version__ = metadata.version("skyr")
 
@@ -18,6 +20,25 @@ DEFAULT_DIR = Path("./script/")
 def _err(msg: str) -> None:
     sys.stderr.write(f"[ERROR] {msg}\n")
     sys.stderr.flush()
+
+
+def find_dir(
+    candidates: Iterable[Union[str, os.PathLike[str], Path]],
+) -> Optional[Path]:
+    """Searches an array for an existent directory.
+
+    :param candidates: Directories or names that will be searched
+    :return: First existent directory, or ``None`` if not found.
+    """
+    for candidate in candidates:
+        if candidate is None:
+            continue
+
+        candidate_path = Path(candidate)
+        if candidate_path.is_dir() and candidate_path.exists():
+            return candidate_path.resolve()
+
+    return None
 
 
 def find_script(name: str, script_dir: Path = DEFAULT_DIR) -> Optional[Path]:

--- a/skyr.py
+++ b/skyr.py
@@ -111,7 +111,8 @@ def _get_parser() -> argparse.ArgumentParser:
         "--script-dir",
         default=argparse.SUPPRESS,
         type=Path,
-        help="Script directory.",
+        help="Script directory. If not provided, Skyr will look for scripts in"
+             "'.skyr' and then 'script'",
         metavar="DIR",
     )
     return parser

--- a/skyr.py
+++ b/skyr.py
@@ -34,9 +34,6 @@ def find_dir(
     :return: First existent directory, or ``None`` if not found.
     """
     for candidate in candidates:
-        if candidate is None:
-            continue
-
         candidate_path = Path(candidate)
         if candidate_path.is_dir() and candidate_path.exists():
             return candidate_path.resolve()

--- a/tests/skyr_test.py
+++ b/tests/skyr_test.py
@@ -123,6 +123,19 @@ def test_main(script_name: str, monkeypatch):
         assert excinfo.value.code == 1
 
 
+def test_main_fails_if_no_script_dir_found(monkeypatch, capsys):
+    with monkeypatch.context() as m:
+        m.chdir(ASSETS_DIR / "bad_cwd")
+
+        with pytest.raises(SystemExit) as excinfo:
+            skyr.main()
+
+        assert excinfo.value.code == 1
+
+        _, err = capsys.readouterr()
+        assert "No script directory found." in err
+
+
 @pytest.mark.parametrize(
     ("argv", "expected_out"), [
         ([], b"I'm a build script"),

--- a/tests/skyr_test.py
+++ b/tests/skyr_test.py
@@ -43,36 +43,23 @@ def test_find_dir(
 
 
 @pytest.mark.parametrize(
-    ("name", "script_dir", "return_value", "expected_err"), [
-        ("build", None, ASSETS_DIR / "script/build", None),
-        ("build", "./other_dir", ASSETS_DIR / "other_dir/build", None),
-        ("build", "./doesnt-exist", None, "Script directory doesn't exist"),
-        ("build", "./a_file", None, "Script directory is not a directory"),
-        ("doesnt-exist", None, None, "Script doesn't exist"),
-        ("a_dir", None, None, "Script is not a file"),
+    ("name", "return_value", "expected_err"), [
+        ("build", ASSETS_DIR / "script/build", None),
+        ("doesnt-exist", None, "Script doesn't exist"),
+        ("a_dir", None, "Script is not a file"),
     ],
 )
 def test_find_script(
     name: str,
-    script_dir: Optional[str],
     return_value: Optional[Path],
     expected_err: Optional[str],
     capsys,
-    monkeypatch,
 ):
-    with monkeypatch.context() as m:
-        m.chdir(Path(__file__).parent / "assets")
+    assert skyr.find_script(name, ASSETS_DIR / "script") == return_value
 
-        if script_dir is None:
-            actual = skyr.find_script(name)
-        else:
-            actual = skyr.find_script(name, Path(script_dir))
+    if expected_err is not None:
         captured = capsys.readouterr()
-
-        assert actual == return_value
-
-        if expected_err is not None:
-            assert expected_err in captured.err
+        assert expected_err in captured.err
 
 
 @pytest.mark.parametrize(

--- a/tests/skyr_test.py
+++ b/tests/skyr_test.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Iterable
 from typing import List
 from typing import Optional
+from typing import Sequence
 
 import pytest
 
@@ -108,17 +109,17 @@ def test_try_execute(
 
 
 @pytest.mark.parametrize(
-    "script_name", [
-        "doesnt_exist",
-        "no-shebang",
+    "argv", [
+        ["doesnt_exist"],
+        ["no-shebang"],
     ],
 )
-def test_main(script_name: str, monkeypatch):
+def test_main_fails(argv: Sequence[str], monkeypatch):
     with monkeypatch.context() as m:
         m.chdir(Path(__file__).parent / "assets")
 
         with pytest.raises(SystemExit) as excinfo:
-            skyr.main(script_name)
+            skyr.main(argv)
 
         assert excinfo.value.code == 1
 

--- a/tests/skyr_test.py
+++ b/tests/skyr_test.py
@@ -95,6 +95,17 @@ def test_try_execute(
         assert expected_err in err
 
 
+def test_main_warns_if_provided_script_dir_doesnt_exist(monkeypatch, capsys):
+    with monkeypatch.context() as m:
+        m.chdir(ASSETS_DIR / "bad_cwd")
+
+        with pytest.raises(SystemExit):
+            skyr.main(["--script-dir", "my-scripts"])
+
+        _, err = capsys.readouterr()
+        assert "Script directory not found" in err
+
+
 @pytest.mark.parametrize(
     "argv", [
         ["doesnt_exist"],

--- a/tests/skyr_test.py
+++ b/tests/skyr_test.py
@@ -1,5 +1,6 @@
 import subprocess
 from pathlib import Path
+from typing import Iterable
 from typing import List
 from typing import Optional
 
@@ -19,6 +20,25 @@ ASSETS_DIR = Path(__file__).parent / "assets"
 def test_argpase_exits_zero(argv: List[str], return_code: int):
     with pytest.raises(SystemExit):
         assert skyr.main(argv) == return_code
+
+
+@pytest.mark.parametrize(
+    ("candidates", "return_value"), [
+        ([], None),
+        (["nonexistentdir"], None),
+        (["script"], ASSETS_DIR / "script"),
+        (["nonexistentdir", "other_dir"], ASSETS_DIR / "other_dir"),
+        (["a_file"], None),
+    ],
+)
+def test_find_dir(
+    candidates: Iterable[str],
+    return_value: Optional[Path],
+    monkeypatch,
+):
+    with monkeypatch.context() as m:
+        m.chdir(Path(__file__).parent / "assets")
+        assert skyr.find_dir(candidates) == return_value
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #9

This also adds the fallback mechanics: If the provided `script-dir` doesn't exist, a warning gets printed and `.skyr`/`script` will get searched instead.